### PR TITLE
Support ImageToPaa as texture conversion tool

### DIFF
--- a/p3drender/__init__.py
+++ b/p3drender/__init__.py
@@ -81,15 +81,17 @@ def find_file(p3dfile, path):
     raise FileNotFoundError("Failed to find {}".format(path))
 
 
-def convert_texture(p3dfile, paa):
+def convert_texture(p3dfile, paa, args):
     if paa == "" or paa[0] == "#":
         return ""
 
     path = find_file(p3dfile, paa)
     result = get_tempfile(".png")
-    subprocess.call(["armake", "paa2img", path, result])
+    if args["--converter"] == "imagetopaa":
+        subprocess.call(["imagetopaa", path, result])
+    else:
+        subprocess.call(["armake", "paa2img", path, result])
     return result
-
 
 def render(p3dfile, outfile, args):
     print("Loading P3D ...")
@@ -115,7 +117,7 @@ def render(p3dfile, outfile, args):
     mati = [textures.index(x.texture) for x in lod.faces]
 
     print("Converting textures ...")
-    textures = [convert_texture(p3dfile, x) for x in textures]
+    textures = [convert_texture(p3dfile, x, args) for x in textures]
 
     print("Building script ...")
     script = build_render_script(outfile, {

--- a/scripts/p3drender
+++ b/scripts/p3drender
@@ -14,6 +14,7 @@ Options:
                                 item (front-left perspective, 512x512) 
                                 (Overwrites other options)
     -c, --camera <xyz>      Camera position in form x,y,z [default: 0,-5,0]
+    --converter imagetopaa  Override use of armake by specifying imagetopaa
     -r, --resolution <res>  Output resolution in form x,y [default: 512,512]
     -t, --translate <xyz>   Translation to apply to object [default: 0,0,0]
     -o, --orthographic      Set camera to orthographic instead of perspective


### PR DESCRIPTION
Allows utilizing ImageToPaa from Arma 3 Tools for texture conversion
Makes armake an optional dependency for Windows users