### PR TITLE
Improve Blender output file path handling

### DIFF
--- a/p3drender/__init__.py
+++ b/p3drender/__init__.py
@@ -128,6 +128,7 @@ def render(p3dfile, outfile, args):
     textures = [convert_texture(p3dfile, x, args) for x in textures]
 
     print("Building script ...")
+    outfile = os.path.abspath(outfile).replace("\\", "\\\\")
     script = build_render_script(outfile, {
             "TEXTURES": textures,
             "VERTS": points,


### PR DESCRIPTION
Make sure outfile path is absolute before transfering to Blender
If argument file path is relative it will be relative to Blender env
By default on Windows this is C:\

Backslash needs to be escaped since it its used as python script